### PR TITLE
fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ SRC = execution.c \
 		builtins/ft_export_utils.c \
 		builtins/ft_exit.c \
 		builtins/ft_cd.c \
+		builtins/ft_echo.c
 
 OBJS = $(SRC:.c=.o)
 

--- a/builtins/builtins.c
+++ b/builtins/builtins.c
@@ -6,80 +6,47 @@
 /*   By: auspensk <auspensk@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/26 14:27:31 by auspensk          #+#    #+#             */
-/*   Updated: 2024/09/23 14:54:13 by auspensk         ###   ########.fr       */
+/*   Updated: 2024/09/27 15:04:15 by auspensk         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../minishell.h"
 
-int	ft_pwd(t_cmd *cmd, t_data *data)
+void	ft_pwd(t_cmd *cmd, t_data *data)
 {
 	char	*dir;
 
 	cmd->cmd_check = BLTN;
 	data->st_code = 0;
 	if (redirect(cmd, data))
-		return (1);
+		return ;
 	dir = getcwd(NULL, 0);
 	if (!dir)
 	{
 		data->st_code = 1;
-		return (1);
+		return ;
 	}
 	write(1, dir, strlen(dir));
 	write(1, "\n", 1);
 	free(dir);
 	dir = NULL;
-	return (0);
+	return ;
 }
 
-int	ft_echo(t_cmd *cmd, t_data *data)
+void	ft_envp(t_cmd *cmd, t_data *data)
 {
-	int		i;
-
 	cmd->cmd_check = BLTN;
 	data->st_code = 0;
 	if (redirect(cmd, data))
-		return (1);
-	i = 1;
-	if (!cmd->args[1])
-		write(1, "\n", 1);
-	else
-	{
-		if (!strcmp(cmd->args[1], "-n"))
-			i = 2;
-		while (cmd->args[i + 1])
-		{
-			write(1, cmd->args[i], ft_strlen(cmd->args[i]));
-			write(1, " ", 1);
-			i++;
-		}
-		if (cmd->args[i])
-			write(1, cmd->args[i], ft_strlen(cmd->args[i]));
-		if (strcmp(cmd->args[1], "-n"))
-			write(1, "\n", 1);
-	}
-	return (0);
+		return ;
+	print_array(data->envp);
+	return ;
 }
 
-int	check_builtin(t_cmd *cmd, t_data *data)
+int	set_output(t_cmd *cmd, t_data *data)
 {
 	int	tty_fd;
 
-	if (!ft_strcmp(cmd->cmd, "pwd"))
-		ft_pwd(cmd, data);
-	else if (!ft_strcmp(cmd->cmd, "cd"))
-		ft_cd(cmd, data);
-	else if (!ft_strcmp(cmd->cmd, "echo"))
-		ft_echo(cmd, data);
-	else if (!ft_strcmp(cmd->cmd, "export"))
-		ft_export(cmd->args[1], cmd, data);
-	else if (!ft_strcmp(cmd->cmd, "unset"))
-		ft_unset(cmd, data);
-	else if (!ft_strcmp(cmd->cmd, "env"))
-		print_array(data->envp);
-	else if (!ft_strcmp(cmd->cmd, "exit"))
-		ft_exit(cmd, data);
 	if (cmd->cmd_check == BLTN)
 	{
 		tty_fd = open(data->tty_out, O_RDWR, O_APPEND);
@@ -87,6 +54,30 @@ int	check_builtin(t_cmd *cmd, t_data *data)
 		close(tty_fd);
 		return (1);
 	}
-	else
-		return (0);
+	return (0);
+}
+
+int	check_builtin(t_cmd *cmd, t_data *data)
+{
+	if (!ft_strcmp(cmd->cmd, "pwd"))
+		ft_pwd(cmd, data);
+	else if (!ft_strcmp(cmd->cmd, "cd"))
+		ft_cd(cmd, data);
+	else if (!ft_strcmp(cmd->cmd, "echo"))
+		ft_echo(cmd, data);
+	else if (!ft_strcmp(cmd->cmd, "export"))
+	{
+		if (ft_export(cmd->args[1], cmd, data))
+			data->st_code = 1;
+	}
+	else if (!ft_strcmp(cmd->cmd, "unset"))
+	{
+		if (ft_unset(cmd, data))
+			data->st_code = 1;
+	}
+	else if (!ft_strcmp(cmd->cmd, "env"))
+		ft_envp(cmd, data);
+	else if (!ft_strcmp(cmd->cmd, "exit"))
+		ft_exit(cmd, data);
+	return (set_output (cmd, data));
 }

--- a/builtins/ft_cd.c
+++ b/builtins/ft_cd.c
@@ -6,13 +6,13 @@
 /*   By: auspensk <auspensk@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/11 13:55:32 by auspensk          #+#    #+#             */
-/*   Updated: 2024/09/23 10:50:09 by auspensk         ###   ########.fr       */
+/*   Updated: 2024/09/27 15:08:51 by auspensk         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../minishell.h"
 
-int	cd_error(char *msg, t_cmd *cmd, t_data *data, char *oldpwd)
+void	cd_error(char *msg, t_cmd *cmd, t_data *data, char *oldpwd)
 {
 	write(2, "cd: ", 4);
 	if (msg)
@@ -22,7 +22,7 @@ int	cd_error(char *msg, t_cmd *cmd, t_data *data, char *oldpwd)
 	data->st_code = 1;
 	if (oldpwd)
 		free(oldpwd);
-	return (1);
+	return ;
 }
 
 int	to_home(t_cmd *cmd, t_data *data)
@@ -41,7 +41,7 @@ int	to_home(t_cmd *cmd, t_data *data)
 	return (0);
 }
 
-int	set_envp(char **oldpwd, t_data *data)
+void	set_envp(char **oldpwd, t_data *data)
 {
 	char	*cur_dir;
 	char	*pwd_dir;
@@ -50,7 +50,7 @@ int	set_envp(char **oldpwd, t_data *data)
 	{
 		data->st_code = 1;
 		free (*oldpwd);
-		return (1);
+		return ;
 	}
 	cur_dir = getcwd(NULL, 0);
 	pwd_dir = ft_strjoin("PWD=", cur_dir);
@@ -59,34 +59,14 @@ int	set_envp(char **oldpwd, t_data *data)
 	{
 		data->st_code = 1;
 		free(pwd_dir);
-		return (1);
+		return ;
 	}
 	free(pwd_dir);
 	free(*oldpwd);
-	return (0);
+	return ;
 }
 
-void	prev_dir(t_cmd *cmd, t_data *data)
-{
-	int	i;
-
-	i = 0;
-	while (data->envp[i])
-	{
-		if (!ft_strncmp(data->envp[i], "OLDPWD=", 7))
-		{
-			free(cmd->args[1]);
-			cmd->args[1] = NULL;
-			cmd->args[1] = ft_strdup(data->envp[i] + 7);
-			write(1, cmd->args[1], ft_strlen(cmd->args[1]));
-			write(1, "\n", 1);
-			break ;
-		}
-		i++;
-	}
-}
-
-int	ft_cd(t_cmd *cmd, t_data *data)
+void	ft_cd(t_cmd *cmd, t_data *data)
 {
 	char	*oldpwd;
 	char	*cur_dir;
@@ -95,14 +75,14 @@ int	ft_cd(t_cmd *cmd, t_data *data)
 	cmd->cmd_check = BLTN;
 	oldpwd = NULL;
 	if (redirect(cmd, data))
-		return (clean_exit(NULL, 1, data));
+		return ;
 	if (!cmd->args[1])
 	{
 		if (to_home(cmd, data))
 			return (cd_error("HOME not set\n", cmd, data, NULL));
 	}
-	if (!ft_strcmp(cmd->args[1], "-"))
-		prev_dir(cmd, data);
+	if (cmd->args[2])
+		return (cd_error("too many arguments\n", cmd, data, NULL));
 	cur_dir = getcwd(NULL, 0);
 	if (!cur_dir)
 		return (cd_error(NULL, cmd, data, oldpwd));

--- a/builtins/ft_echo.c
+++ b/builtins/ft_echo.c
@@ -1,0 +1,53 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   ft_echo.c                                          :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: auspensk <auspensk@student.42.fr>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/09/27 14:52:44 by auspensk          #+#    #+#             */
+/*   Updated: 2024/09/27 15:09:25 by auspensk         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "../minishell.h"
+
+void	write_echo(t_cmd *cmd)
+{
+	int	i;
+
+	i = 1;
+	if (!strcmp(cmd->args[1], "-n"))
+		i = 2;
+	while (cmd->args[i + 1])
+	{
+		write(1, cmd->args[i], ft_strlen(cmd->args[i]));
+		write(1, " ", 1);
+		i++;
+	}
+	if (cmd->args[i])
+		write(1, cmd->args[i], ft_strlen(cmd->args[i]));
+	if (strcmp(cmd->args[1], "-n"))
+		write(1, "\n", 1);
+}
+
+void	ft_echo(t_cmd *cmd, t_data *data)
+{
+	int	tty_fd;
+
+	cmd->cmd_check = BLTN;
+	data->st_code = 0;
+	if (redirect(cmd, data))
+		return ;
+	if (data->child)
+	{
+		tty_fd = open(data->tty_in, O_RDWR, O_APPEND);
+		dup2(tty_fd, STDIN_FILENO);
+		close(tty_fd);
+	}
+	if (!cmd->args[1])
+		write(1, "\n", 1);
+	else
+		write_echo(cmd);
+	return ;
+}

--- a/builtins/ft_exit.c
+++ b/builtins/ft_exit.c
@@ -6,7 +6,7 @@
 /*   By: auspensk <auspensk@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/11 15:08:30 by auspensk          #+#    #+#             */
-/*   Updated: 2024/09/24 15:12:36 by auspensk         ###   ########.fr       */
+/*   Updated: 2024/09/27 15:08:07 by auspensk         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,45 +18,55 @@ int	err_exit(char *str, t_data *data)
 	write(2, str, ft_strlen(str));
 	write(2, ": numeric argument required\n",
 		ft_strlen(": numeric argument required\n"));
-	data->st_code = 2;
-	clean_exit(NULL, 0, data);
-	exit (data->st_code);
+	exit (clean_exit(NULL, 2, data));
 }
 
-int	parse_ex_status(char *str, t_data *data)
+void	parse_ex_status(char *str, t_data *data)
 {
 	int	status;
 	int	sign;
+	int	i;
 
 	status = 0;
 	sign = 1;
-	if (*str == '\0' || ft_strlen(str) > 18)
-		return (err_exit(str, data));
-	if (*str == '-' || *str == '+')
+	i = 0;
+	if (str[i] == '\0' || ft_strlen(str) > 18)
+		err_exit(str, data);
+	if (str[i] == '-' || str[i] == '+')
+		i++;
+	while (str[i] != '\0')
 	{
-		if (*str == '-')
-			sign = -1;
-		str++;
-	}
-	while (*str != '\0')
-	{
-		if (*str > 47 && *str < 58)
-			status = (status * 10) + (*str - 48);
+		if (str[i] > 47 && *str < 58)
+			status = (status * 10) + (str[i] - 48);
 		else
-			return (err_exit(str, data));
-		str++;
+			err_exit(str, data);
+		i++;
 	}
-	clean_exit(NULL, 0, data);
-	exit (status);
+	while (status > 255)
+		status = status % 256;
+	if (*str == '-')
+		status = 256 - status;
+	exit (clean_exit (NULL, status, data));
 }
 
-int	ft_exit(t_cmd *cmd, t_data *data)
+void	ft_exit(t_cmd *cmd, t_data *data)
 {
 	cmd->cmd_check = BLTN;
 	data->st_code = 0;
-	write(1, "exit\n", ft_strlen("exit\n"));
+	if (redirect(cmd, data))
+	{
+		clean_exit(NULL, data->st_code, data);
+		return ;
+	}
+	if (!data->child)
+		write(1, "exit\n", ft_strlen("exit\n"));
+	if (cmd->args[2])
+	{
+		write(2, "exit: too many arguments\n", 25);
+		data->st_code = 1;
+		return ;
+	}
 	if (cmd->args[1])
 		return (parse_ex_status(cmd->args[1], data));
-	clean_exit(NULL, 0, data);
-	exit (0);
+	exit (clean_exit(NULL, 0, data));
 }

--- a/builtins/ft_export.c
+++ b/builtins/ft_export.c
@@ -6,11 +6,23 @@
 /*   By: auspensk <auspensk@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/03 14:52:52 by auspensk          #+#    #+#             */
-/*   Updated: 2024/09/18 16:15:16 by auspensk         ###   ########.fr       */
+/*   Updated: 2024/09/27 17:07:55 by auspensk         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../minishell.h"
+
+char	*export_err(t_export *export, t_data *data)
+{
+	if (export->type == EXPORT)
+		write(2, "export: '", ft_strlen("export: '"));
+	if (export->type == UNSET)
+		write(2, "unset: '", ft_strlen("unset: '"));
+	write(2, export->arg, ft_strlen(export->arg));
+	write(2, "': not a valid identifier\n", 26);
+	data->st_code = 1;
+	return (NULL);
+}
 
 char	*check_argument(t_export *export, t_data *data)
 {
@@ -19,21 +31,16 @@ char	*check_argument(t_export *export, t_data *data)
 
 	i = 0;
 	res = NULL;
-	while (ft_isalnum(export->arg[i]))
+	if (!ft_isalpha(export->arg[i]) && export->arg[i] != '_')
+		return (export_err(export, data));
+	while (ft_isalnum(export->arg[i]) || export->arg[i] == '_')
 		i++;
 	if (i && export->arg[i] == '\0')
 		res = strdup(export->arg);
 	else if (i && export->arg[i] == '=' && export->type == EXPORT)
 		res = ft_substr(export->arg, 0, i);
 	else
-	{
-		if (export->type == EXPORT)
-			write(2, "export: '", ft_strlen("export: '"));
-		if (export->type == UNSET)
-			write(2, "unset: '", ft_strlen("unset: '"));
-		write(2, export->arg, ft_strlen(export->arg));
-		write(2, "': not a valid identifier\n", 26);
-	}
+		return (export_err(export, data));
 	if (!res)
 		data->st_code = 1;
 	return (res);
@@ -90,7 +97,7 @@ int	ft_unset(t_cmd *cmd, t_data *data)
 	if (redirect(cmd, data))
 		return (1);
 	if (!cmd->args[1])
-		return (1);
+		return (0);
 	export.arg = cmd->args[1];
 	export.type = UNSET;
 	export.key = check_argument(&export, data);

--- a/builtins/ft_export_utils.c
+++ b/builtins/ft_export_utils.c
@@ -6,7 +6,7 @@
 /*   By: auspensk <auspensk@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/10 10:47:44 by auspensk          #+#    #+#             */
-/*   Updated: 2024/09/16 15:18:39 by auspensk         ###   ########.fr       */
+/*   Updated: 2024/09/27 17:08:45 by auspensk         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,11 +18,11 @@ int	print_array(char **array)
 
 	i = 0;
 	if (!array)
-		return (0);
+		return (1);
 	while (array[i])
 	{
-		write(1, array[i], ft_strlen(array[i]));
-		write(1, "\n", 1);
+		write(STDOUT_FILENO, array[i], ft_strlen(array[i]));
+		write(STDOUT_FILENO, "\n", 1);
 		i++;
 	}
 	return (0);
@@ -67,5 +67,5 @@ int	find_key(t_export *export, char **envp, t_data *data)
 		}
 		i++;
 	}
-	return (1);
+	return (0);
 }

--- a/cleaning.c
+++ b/cleaning.c
@@ -6,7 +6,7 @@
 /*   By: auspensk <auspensk@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/20 16:54:48 by auspensk          #+#    #+#             */
-/*   Updated: 2024/09/23 10:46:41 by auspensk         ###   ########.fr       */
+/*   Updated: 2024/09/27 10:20:57 by auspensk         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -70,6 +70,28 @@ void	free_pids(t_data *data)
 	}
 }
 
+void free_sas(t_data *data)
+{
+	if (data->sa)
+		free(data->sa);
+	if (data->sa_child)
+		free(data->sa_child);
+	if (data->sa_ex)
+		free(data->sa_ex);
+	if (data->sa_quit)
+		free(data->sa_quit);
+	if (data->sa_quit_child)
+		free(data->sa_quit_child);
+	if (data->sa_quit_ex)
+		free(data->sa_quit_ex);
+	data->sa = NULL;
+	data->sa_child = NULL;
+	data->sa_ex = NULL;
+	data->sa_quit = NULL;
+	data->sa_quit_child = NULL;
+	data->sa_quit_ex = NULL;
+}
+
 int	clean_exit(char *msg, int r_value, t_data *data)
 {
 	if (data)
@@ -79,14 +101,7 @@ int	clean_exit(char *msg, int r_value, t_data *data)
 		free_envp(data->envp);
 		data->envp = NULL;
 		free_pids(data);
-		if (data->sa)
-			free(data->sa);
-		if (data->sa_child)
-			free(data->sa_child);
-		if (data->sa_ex)
-			free(data->sa_ex);
-		if (data->sa_quit)
-			free(data->sa_quit);
+		free_sas(data);
 	}
 	if (msg)
 		write(2, msg, ft_strlen(msg));

--- a/execution.c
+++ b/execution.c
@@ -6,7 +6,7 @@
 /*   By: auspensk <auspensk@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/20 15:38:09 by auspensk          #+#    #+#             */
-/*   Updated: 2024/09/24 14:22:38 by auspensk         ###   ########.fr       */
+/*   Updated: 2024/09/27 10:00:51 by auspensk         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -44,6 +44,7 @@ int	child_process(t_cmd *cmd, t_data *data)
 {
 	sigaction(SIGINT, data->sa_child, NULL);
 	sigaction(SIGQUIT, data->sa_quit_child, NULL);
+	data->child = 1;
 	if (cmd->next)
 	{
 		close ((data->fd)[0]);

--- a/inits.c
+++ b/inits.c
@@ -6,7 +6,7 @@
 /*   By: auspensk <auspensk@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/28 12:16:52 by auspensk          #+#    #+#             */
-/*   Updated: 2024/09/24 14:23:05 by auspensk         ###   ########.fr       */
+/*   Updated: 2024/09/27 10:00:24 by auspensk         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -75,6 +75,7 @@ void	init_data(t_data *data, char **envp)
 	data->tty_in = ttyname(STDIN_FILENO);
 	data->tty_out = ttyname(STDOUT_FILENO);
 	data->st_code = 0;
+	data->child = 0;
 	if (!data->envp)
 		exit(clean_exit("failed to init data\n", EXIT_FAILURE, data));
 }

--- a/main.c
+++ b/main.c
@@ -6,7 +6,7 @@
 /*   By: auspensk <auspensk@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/21 15:07:50 by auspensk          #+#    #+#             */
-/*   Updated: 2024/09/24 14:45:51 by auspensk         ###   ########.fr       */
+/*   Updated: 2024/09/27 16:35:22 by auspensk         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -49,8 +49,8 @@ int	main(int argc, char *argv[], char *envp[])
 	t_tok	*head;
 
 	(void)argv;
-	if (!isatty(0) || !isatty(1))
-		return (clean_exit("piping ./execs is not supported\n", errno, NULL));
+	// if (!isatty(0) || !isatty(1))
+	// 	return (clean_exit("piping ./execs is not supported\n", errno, NULL));
 	init_signals(&data);
 	// sigaction(SIGQUIT, data.sa_quit, NULL);
 	// sigaction(SIGINT, data.sa, NULL);

--- a/minishell.h
+++ b/minishell.h
@@ -6,7 +6,7 @@
 /*   By: auspensk <auspensk@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/20 15:56:30 by auspensk          #+#    #+#             */
-/*   Updated: 2024/09/24 14:22:27 by auspensk         ###   ########.fr       */
+/*   Updated: 2024/09/27 15:07:01 by auspensk         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -96,6 +96,7 @@ typedef struct data
 	t_pids				*pids;
 	int					st_code;
 	int					fd[2];
+	int					child;
 	char				**envp;
 	char				**paths;
 	char				*tty_in;
@@ -135,16 +136,15 @@ void	init_data(t_data *data, char **envp);
 
 /*builtins*/
 int		check_builtin(t_cmd *cmd, t_data *data);
-int		ft_echo(t_cmd *cmd, t_data *data);
+void	ft_echo(t_cmd *cmd, t_data *data);
 int		ft_unset(t_cmd *cmd, t_data *data);
 int		find_key(t_export *export, char **envp, t_data *data);
 int		add_entry(char *entry, char **envp, t_data *data);
-int		print_array(char **array);
 int		unset_variable(int i, char **envp, t_data *data);
 int		ft_export(char *arg, t_cmd *cmd, t_data *data);
 int		print_array(char **array);
-int		ft_cd(t_cmd *cmd, t_data *data);
-int		ft_exit(t_cmd *cmd, t_data *data);
+void	ft_cd(t_cmd *cmd, t_data *data);
+void	ft_exit(t_cmd *cmd, t_data *data);
 
 t_tok	*read_input(t_data *data);
 

--- a/redirect.c
+++ b/redirect.c
@@ -6,63 +6,66 @@
 /*   By: auspensk <auspensk@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/25 12:33:17 by auspensk          #+#    #+#             */
-/*   Updated: 2024/09/16 10:35:01 by auspensk         ###   ########.fr       */
+/*   Updated: 2024/09/27 15:52:38 by auspensk         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
 
-int	redirect_error(char *value, t_data *data)
+int	redirect_error(t_cmd *cmd, char *value, t_data *data)
 {
-	close(STDIN_FILENO);
-	close(STDOUT_FILENO);
+	if (cmd->cmd_check != BLTN)
+	{
+		close(STDIN_FILENO);
+		close(STDOUT_FILENO);
+	}
 	perror (value);
 	data->st_code = 1;
 	return (1);
 }
 
-int	duplicate_fds(int *fd_in, int *fd_out)
+int	duplicate_fds(int *fds, t_cmd *cmd)
 {
-	if (*fd_in)
+	if (fds[0] && cmd->cmd_check != BLTN)
 	{
-		dup2(*fd_in, STDIN_FILENO);
-		close(*fd_in);
+		dup2(fds[0], STDIN_FILENO);
+		close(fds[0]);
 	}
-	if (*fd_out)
+	if (fds[1])
 	{
-		dup2(*fd_out, STDOUT_FILENO);
-		close(*fd_out);
+		dup2(fds[1], STDOUT_FILENO);
+		close(fds[1]);
 	}
 	return (0);
 }
 
-int	out_redirect(t_redirect *redirect, int *fd_out, int *fd_in, t_data *data)
+int	out_redirect(t_redirect *redirect, int *fds, t_data *data, t_cmd *cmd)
 {
-	if (*fd_out)
-		close(*fd_out);
+	if (fds[1])
+		close(fds[1]);
 	if (redirect->type == OUTPUT)
-		*fd_out = open(redirect->value, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+		fds[1] = open(redirect->value, O_WRONLY | O_CREAT | O_TRUNC, 0644);
 	else if (redirect->type == APPEND)
-		*fd_out = open(redirect->value, O_CREAT | O_APPEND | O_RDWR, 0644);
-	if (*fd_out < 0)
+		fds[1] = open(redirect->value, O_CREAT | O_APPEND | O_RDWR, 0644);
+	if (fds[1] < 0)
 	{
-		if (*fd_in)
-			close (*fd_in);
-		return (redirect_error(redirect->value, data));
+		if (fds[0])
+			close (fds[0]);
+		return (redirect_error(cmd, redirect->value, data));
 	}
 	return (0);
 }
 
-int	in_redirect(t_redirect *redirect, int *fd_in, int *fd_out, t_data *data)
+int	in_redirect(t_redirect *redirect, int *fds, t_data *data, t_cmd *cmd)
 {
-	if (*fd_in)
-		close(*fd_in);
-	*fd_in = open(redirect->value, O_RDONLY);
-	if (*fd_in < 0)
+	if (fds[0])
+		close(fds[0]);
+	fds[0] = open(redirect->value, O_RDONLY);
+	if (fds[0] < 0)
 	{
-		if (*fd_out)
-			close(*fd_out);
-		return (redirect_error(redirect->value, data));
+		if (fds[1])
+			close(fds[1]);
+		return (redirect_error(cmd, redirect->value, data));
 	}
 	return (0);
 }
@@ -70,26 +73,25 @@ int	in_redirect(t_redirect *redirect, int *fd_in, int *fd_out, t_data *data)
 int	redirect(t_cmd *cmd, t_data *data)
 {
 	int	i;
-	int	fd_in;
-	int	fd_out;
+	int	fds[2];
 
 	i = 0;
-	fd_in = 0;
-	fd_out = 0;
+	fds[0] = 0;
+	fds[1] = 0;
 	while (cmd->redirect[i].value)
 	{
 		if (cmd->redirect[i].type == INPUT || cmd->redirect[i].type == HEREDOC)
 		{
-			if (in_redirect(&(cmd->redirect[i]), &fd_in, &fd_out, data) == 1)
+			if (in_redirect(&(cmd->redirect[i]), fds, data, cmd) == 1)
 				return (1);
 		}
 		if (cmd->redirect[i].type == OUTPUT || cmd->redirect[i].type == APPEND)
 		{
-			if (out_redirect(&(cmd->redirect[i]), &fd_out, &fd_in, data) == 1)
+			if (out_redirect(&(cmd->redirect[i]), fds, data, cmd) == 1)
 				return (1);
 		}
 		i++;
 	}
-	duplicate_fds(&fd_in, &fd_out);
+	duplicate_fds(fds, cmd);
 	return (0);
 }

--- a/tester
+++ b/tester
@@ -43,7 +43,7 @@ commands=(
 )
 
 # Manual Tests that do not work with this script
-# "exit 0"
+# "exit 20"
 # "env"
 # "echo \$?"
 # ...


### PR DESCRIPTION
fixes:
- builtins only accept input as args, not STDIN or any input redirection. Files for redirection are still checked
- fixes to env builtin
- export: check format of arguments
- cd, exit - check number of args
- exit statuses - tracing through builtins 
- exit status: limit to 0-255 when passed to exit builtin as argument
